### PR TITLE
fix(ui): remove unnecessary IntPtr conversion for HWnd

### DIFF
--- a/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
+++ b/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
@@ -67,10 +67,9 @@ namespace CodingWithCalvin.ProjectRenamifier
             var dialog = new RenameProjectDialog(currentName);
 
             // Set the owner to the VS main window for proper modal behavior
-            var hwnd = new IntPtr(dte.MainWindow.HWnd);
             var helper = new WindowInteropHelper(dialog)
             {
-                Owner = hwnd
+                Owner = dte.MainWindow.HWnd
             };
 
             if (dialog.ShowDialog() != true)


### PR DESCRIPTION
## Summary

Fix x64 compilation error caused by unnecessary IntPtr wrapping.

## Problem

```
error CS1503: Argument 1: cannot convert from 'System.IntPtr' to 'int'
```

The `dte.MainWindow.HWnd` property already returns `IntPtr` on x64, so wrapping it in `new IntPtr()` fails because there's no `IntPtr(IntPtr)` constructor.

## Solution

Use `dte.MainWindow.HWnd` directly since it's already the correct type for `WindowInteropHelper.Owner`.