### PR TITLE
feat(namespace): update namespace declarations in source files

### DIFF
--- a/src/CodingWithCalvin.ProjectRenamifier/CodingWithCalvin.ProjectRenamifier.csproj
+++ b/src/CodingWithCalvin.ProjectRenamifier/CodingWithCalvin.ProjectRenamifier.csproj
@@ -71,6 +71,7 @@
     </Compile>
     <Compile Include="ProjectRenamifierPackage.cs" />
     <Compile Include="Services\ProjectFileService.cs" />
+    <Compile Include="Services\SourceFileService.cs" />
     <Compile Include="source.extension.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
+++ b/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
@@ -83,9 +83,11 @@ namespace CodingWithCalvin.ProjectRenamifier
             // Update RootNamespace and AssemblyName in .csproj
             ProjectFileService.UpdateProjectFile(projectFilePath, currentName, newName);
 
+            // Update namespace declarations in source files
+            SourceFileService.UpdateNamespacesInProject(projectFilePath, currentName, newName);
+
             // TODO: Implement remaining rename operations
             // See open issues for requirements:
-            // - #8: Update namespace declarations in source files
             // - #9: Update using statements across solution
             // - #11: Solution folder support
             // - #12: Progress indication

--- a/src/CodingWithCalvin.ProjectRenamifier/Services/SourceFileService.cs
+++ b/src/CodingWithCalvin.ProjectRenamifier/Services/SourceFileService.cs
@@ -1,0 +1,108 @@
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace CodingWithCalvin.ProjectRenamifier.Services
+{
+    /// <summary>
+    /// Service for updating namespace declarations in source files.
+    /// </summary>
+    internal static class SourceFileService
+    {
+        /// <summary>
+        /// Updates namespace declarations in all .cs files within the project directory.
+        /// </summary>
+        /// <param name="projectFilePath">Full path to the .csproj file.</param>
+        /// <param name="oldNamespace">The old namespace to find.</param>
+        /// <param name="newNamespace">The new namespace to replace with.</param>
+        /// <returns>The number of files modified.</returns>
+        public static int UpdateNamespacesInProject(string projectFilePath, string oldNamespace, string newNamespace)
+        {
+            var projectDirectory = Path.GetDirectoryName(projectFilePath);
+            if (string.IsNullOrEmpty(projectDirectory))
+            {
+                return 0;
+            }
+
+            var csFiles = Directory.GetFiles(projectDirectory, "*.cs", SearchOption.AllDirectories);
+            var modifiedCount = 0;
+
+            foreach (var filePath in csFiles)
+            {
+                if (UpdateNamespacesInFile(filePath, oldNamespace, newNamespace))
+                {
+                    modifiedCount++;
+                }
+            }
+
+            return modifiedCount;
+        }
+
+        /// <summary>
+        /// Updates namespace declarations in a single source file.
+        /// </summary>
+        /// <param name="filePath">Full path to the .cs file.</param>
+        /// <param name="oldNamespace">The old namespace to find.</param>
+        /// <param name="newNamespace">The new namespace to replace with.</param>
+        /// <returns>True if the file was modified, false otherwise.</returns>
+        public static bool UpdateNamespacesInFile(string filePath, string oldNamespace, string newNamespace)
+        {
+            // Detect file encoding
+            var encoding = DetectEncoding(filePath);
+            var content = File.ReadAllText(filePath, encoding);
+            var originalContent = content;
+
+            // Pattern for block-scoped namespace: namespace OldName { or namespace OldName\n{
+            // Also handles nested: namespace OldName.Something
+            var blockPattern = $@"(\bnamespace\s+){Regex.Escape(oldNamespace)}(\s*[\{{\r\n]|\.|\s*$)";
+            content = Regex.Replace(content, blockPattern, $"$1{newNamespace}$2");
+
+            // Pattern for file-scoped namespace: namespace OldName;
+            // Also handles nested: namespace OldName.Something;
+            var fileScopedPattern = $@"(\bnamespace\s+){Regex.Escape(oldNamespace)}(\.[\w.]*)?(\s*;)";
+            content = Regex.Replace(content, fileScopedPattern, $"$1{newNamespace}$2$3");
+
+            if (content != originalContent)
+            {
+                File.WriteAllText(filePath, content, encoding);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Detects the encoding of a file, defaulting to UTF-8 if not determinable.
+        /// </summary>
+        private static Encoding DetectEncoding(string filePath)
+        {
+            // Read the BOM to detect encoding
+            var bom = new byte[4];
+            using (var file = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+            {
+                file.Read(bom, 0, 4);
+            }
+
+            // Detect encoding from BOM
+            if (bom[0] == 0xef && bom[1] == 0xbb && bom[2] == 0xbf)
+            {
+                return Encoding.UTF8;
+            }
+            if (bom[0] == 0xff && bom[1] == 0xfe && bom[2] == 0 && bom[3] == 0)
+            {
+                return Encoding.UTF32;
+            }
+            if (bom[0] == 0xff && bom[1] == 0xfe)
+            {
+                return Encoding.Unicode; // UTF-16 LE
+            }
+            if (bom[0] == 0xfe && bom[1] == 0xff)
+            {
+                return Encoding.BigEndianUnicode; // UTF-16 BE
+            }
+
+            // Default to UTF-8 without BOM
+            return new UTF8Encoding(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add functionality to update namespace declarations in all .cs files within the project when renaming.

## Changes Made

- **New:** `Services/SourceFileService.cs` - Utility class for source file namespace updates
  - `UpdateNamespacesInProject()` - Scans all .cs files in project directory
  - `UpdateNamespacesInFile()` - Updates namespaces in a single file
  - Handles block-scoped namespaces: `namespace OldName { }`
  - Handles file-scoped namespaces: `namespace OldName;`
  - Handles nested namespaces: `namespace OldName.SubNamespace`
  - Preserves file encoding (detects BOM for UTF-8, UTF-16, UTF-32)
- **Modified:** `RenamifyProjectCommand.cs` - Calls SourceFileService after updating project file
- **Modified:** `.csproj` - Added new file reference

## Test Plan

- [ ] Build and debug the extension
- [ ] Create a test project with various namespace styles:
  - Block-scoped: `namespace MyProject { }`
  - File-scoped: `namespace MyProject;`
  - Nested: `namespace MyProject.Models { }`
- [ ] Rename the project
- [ ] Verify all namespace declarations are updated
- [ ] Verify nested namespaces preserve their suffix (e.g., `NewName.Models`)
- [ ] Verify file encoding is preserved

Closes #8