### PR TITLE
feat(rename): rename project file on disk

### DIFF
--- a/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
+++ b/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
@@ -86,8 +86,14 @@ namespace CodingWithCalvin.ProjectRenamifier
             // Update namespace declarations in source files
             SourceFileService.UpdateNamespacesInProject(projectFilePath, currentName, newName);
 
+            // Rename the project file on disk
+            projectFilePath = ProjectFileService.RenameProjectFile(projectFilePath, newName);
+
             // TODO: Implement remaining rename operations
             // See open issues for requirements:
+            // - #21: Rename parent directory if it matches project name
+            // - #22: Remove and re-add project to solution
+            // - #23: Update project references
             // - #9: Update using statements across solution
             // - #11: Solution folder support
             // - #12: Progress indication

--- a/src/CodingWithCalvin.ProjectRenamifier/Services/ProjectFileService.cs
+++ b/src/CodingWithCalvin.ProjectRenamifier/Services/ProjectFileService.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Xml;
 
 namespace CodingWithCalvin.ProjectRenamifier.Services
@@ -7,6 +8,24 @@ namespace CodingWithCalvin.ProjectRenamifier.Services
     /// </summary>
     internal static class ProjectFileService
     {
+        /// <summary>
+        /// Renames the project file on disk.
+        /// </summary>
+        /// <param name="projectFilePath">Full path to the current .csproj file.</param>
+        /// <param name="newName">The new project name (without extension).</param>
+        /// <returns>The new full path to the renamed project file.</returns>
+        public static string RenameProjectFile(string projectFilePath, string newName)
+        {
+            var directory = Path.GetDirectoryName(projectFilePath);
+            var extension = Path.GetExtension(projectFilePath);
+            var newFileName = newName + extension;
+            var newFilePath = Path.Combine(directory, newFileName);
+
+            File.Move(projectFilePath, newFilePath);
+
+            return newFilePath;
+        }
+
         /// <summary>
         /// Updates the RootNamespace and AssemblyName elements in a project file
         /// if they match the old project name.


### PR DESCRIPTION
## Summary

Add functionality to rename the actual .csproj file on disk.

## Changes Made

- **Modified:** `Services/ProjectFileService.cs`
  - Added `RenameProjectFile()` method
  - Uses full paths via `Path.GetDirectoryName()` and `Path.Combine()`
  - Preserves file extension
  - Returns new file path for subsequent operations
- **Modified:** `Commands/RenamifyProjectCommand.cs`
  - Calls `RenameProjectFile()` after updating namespaces
  - Updated TODO comments with new issue references

## Test Plan

- [ ] Build and debug the extension
- [ ] Right-click a project and rename it
- [ ] Verify the .csproj file is renamed on disk
- [ ] Verify file extension is preserved

## Note

After this change, the solution will be in a broken state because the project path in the .sln still points to the old file. Issues #21, #22, #23 will complete the rename workflow.

Closes #20