### PR TITLE
feat(rename): rename project file and parent directory

### DIFF
--- a/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
+++ b/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
@@ -86,8 +86,16 @@ namespace CodingWithCalvin.ProjectRenamifier
             // Update namespace declarations in source files
             SourceFileService.UpdateNamespacesInProject(projectFilePath, currentName, newName);
 
+            // Rename parent directory if it matches project name
+            projectFilePath = ProjectFileService.RenameParentDirectoryIfMatches(projectFilePath, currentName, newName);
+
+            // Rename the project file on disk
+            projectFilePath = ProjectFileService.RenameProjectFile(projectFilePath, newName);
+
             // TODO: Implement remaining rename operations
             // See open issues for requirements:
+            // - #22: Remove and re-add project to solution
+            // - #23: Update project references
             // - #9: Update using statements across solution
             // - #11: Solution folder support
             // - #12: Progress indication

--- a/src/CodingWithCalvin.ProjectRenamifier/Services/ProjectFileService.cs
+++ b/src/CodingWithCalvin.ProjectRenamifier/Services/ProjectFileService.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Xml;
 
 namespace CodingWithCalvin.ProjectRenamifier.Services
@@ -7,6 +8,57 @@ namespace CodingWithCalvin.ProjectRenamifier.Services
     /// </summary>
     internal static class ProjectFileService
     {
+        /// <summary>
+        /// Renames the project file on disk.
+        /// </summary>
+        /// <param name="projectFilePath">Full path to the current .csproj file.</param>
+        /// <param name="newName">The new project name (without extension).</param>
+        /// <returns>The new full path to the renamed project file.</returns>
+        public static string RenameProjectFile(string projectFilePath, string newName)
+        {
+            var directory = Path.GetDirectoryName(projectFilePath);
+            var extension = Path.GetExtension(projectFilePath);
+            var newFileName = newName + extension;
+            var newFilePath = Path.Combine(directory, newFileName);
+
+            File.Move(projectFilePath, newFilePath);
+
+            return newFilePath;
+        }
+
+        /// <summary>
+        /// Renames the parent directory if its name matches the old project name.
+        /// </summary>
+        /// <param name="projectFilePath">Full path to the .csproj file.</param>
+        /// <param name="oldName">The old project name to match against.</param>
+        /// <param name="newName">The new project name.</param>
+        /// <returns>The new full path to the project file after directory rename, or the original path if no rename occurred.</returns>
+        public static string RenameParentDirectoryIfMatches(string projectFilePath, string oldName, string newName)
+        {
+            var projectDirectory = Path.GetDirectoryName(projectFilePath);
+            var parentDirectory = Directory.GetParent(projectDirectory);
+
+            if (parentDirectory == null)
+            {
+                return projectFilePath;
+            }
+
+            var directoryName = new DirectoryInfo(projectDirectory).Name;
+
+            // Only rename if directory name matches the old project name
+            if (!directoryName.Equals(oldName, StringComparison.OrdinalIgnoreCase))
+            {
+                return projectFilePath;
+            }
+
+            var newDirectoryPath = Path.Combine(parentDirectory.FullName, newName);
+            Directory.Move(projectDirectory, newDirectoryPath);
+
+            // Return the new project file path
+            var fileName = Path.GetFileName(projectFilePath);
+            return Path.Combine(newDirectoryPath, fileName);
+        }
+
         /// <summary>
         /// Updates the RootNamespace and AssemblyName elements in a project file
         /// if they match the old project name.


### PR DESCRIPTION
## Summary

Add functionality to rename the project file and parent directory on disk.

## Changes Made

- **Modified:** `Services/ProjectFileService.cs`
  - Added `RenameProjectFile()` - Renames the .csproj file
  - Added `RenameParentDirectoryIfMatches()` - Renames parent folder if it matches project name
  - Uses full paths via `Path` and `DirectoryInfo` classes
  - Directory rename only occurs if folder name matches old name (case-insensitive)
  - Both methods return new path for subsequent operations
- **Modified:** `Commands/RenamifyProjectCommand.cs`
  - Calls directory rename first (moves entire folder)
  - Then calls file rename (renames just the .csproj)
  - Updated TODO comments

## Example

```
Before: C:\Projects\MyProject\MyProject.csproj
After:  C:\Projects\NewName\NewName.csproj
```

## Test Plan

- [ ] Build and debug the extension
- [ ] Test with project where folder matches project name - both should rename
- [ ] Test with project where folder differs from project name - only file should rename
- [ ] Verify paths are calculated correctly

## Note

Solution will still be broken after this runs until #22, #23 are implemented.

Closes #20
Closes #21