### PR TITLE
feat(services): add solution remove and re-add project during rename

### DIFF
--- a/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
+++ b/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
@@ -80,11 +80,23 @@ namespace CodingWithCalvin.ProjectRenamifier
             var newName = dialog.NewProjectName;
             var projectFilePath = project.FullName;
 
+            // Remove project from solution before file operations
+            dte.Solution.Remove(project);
+
             // Update RootNamespace and AssemblyName in .csproj
             ProjectFileService.UpdateProjectFile(projectFilePath, currentName, newName);
 
             // Update namespace declarations in source files
             SourceFileService.UpdateNamespacesInProject(projectFilePath, currentName, newName);
+
+            // Rename the project file on disk
+            var newProjectFilePath = ProjectFileService.RenameProjectFile(projectFilePath, newName);
+
+            // Rename parent directory if it matches the old project name
+            newProjectFilePath = ProjectFileService.RenameParentDirectoryIfMatches(newProjectFilePath, currentName, newName);
+
+            // Re-add project to solution with new path
+            dte.Solution.AddFromFile(newProjectFilePath);
 
             // TODO: Implement remaining rename operations
             // See open issues for requirements:

--- a/src/CodingWithCalvin.ProjectRenamifier/Services/ProjectFileService.cs
+++ b/src/CodingWithCalvin.ProjectRenamifier/Services/ProjectFileService.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Xml;
 
 namespace CodingWithCalvin.ProjectRenamifier.Services
@@ -7,6 +8,57 @@ namespace CodingWithCalvin.ProjectRenamifier.Services
     /// </summary>
     internal static class ProjectFileService
     {
+        /// <summary>
+        /// Renames the project file on disk.
+        /// </summary>
+        /// <param name="projectFilePath">Full path to the current .csproj file.</param>
+        /// <param name="newName">The new project name (without extension).</param>
+        /// <returns>The new full path to the renamed project file.</returns>
+        public static string RenameProjectFile(string projectFilePath, string newName)
+        {
+            var directory = Path.GetDirectoryName(projectFilePath);
+            var extension = Path.GetExtension(projectFilePath);
+            var newFileName = newName + extension;
+            var newFilePath = Path.Combine(directory, newFileName);
+
+            File.Move(projectFilePath, newFilePath);
+
+            return newFilePath;
+        }
+
+        /// <summary>
+        /// Renames the parent directory if its name matches the old project name.
+        /// </summary>
+        /// <param name="projectFilePath">Full path to the .csproj file.</param>
+        /// <param name="oldName">The old project name to match against.</param>
+        /// <param name="newName">The new project name.</param>
+        /// <returns>The new full path to the project file after directory rename, or the original path if no rename occurred.</returns>
+        public static string RenameParentDirectoryIfMatches(string projectFilePath, string oldName, string newName)
+        {
+            var projectDirectory = Path.GetDirectoryName(projectFilePath);
+            var parentDirectory = Directory.GetParent(projectDirectory);
+
+            if (parentDirectory == null)
+            {
+                return projectFilePath;
+            }
+
+            var directoryName = new DirectoryInfo(projectDirectory).Name;
+
+            // Only rename if directory name matches the old project name
+            if (!directoryName.Equals(oldName, StringComparison.OrdinalIgnoreCase))
+            {
+                return projectFilePath;
+            }
+
+            var newDirectoryPath = Path.Combine(parentDirectory.FullName, newName);
+            Directory.Move(projectDirectory, newDirectoryPath);
+
+            // Return the new project file path
+            var fileName = Path.GetFileName(projectFilePath);
+            return Path.Combine(newDirectoryPath, fileName);
+        }
+
         /// <summary>
         /// Updates the RootNamespace and AssemblyName elements in a project file
         /// if they match the old project name.


### PR DESCRIPTION
## Summary
- Adds `RenameProjectFile` method to rename .csproj file on disk
- Adds `RenameParentDirectoryIfMatches` method to rename project directory when it matches the old project name
- Updates `RenameProject` command to remove project from solution before file operations
- Re-adds project to solution with the new path after rename completes

## Test plan
- [ ] Rename a project and verify the .csproj file is renamed on disk
- [ ] Verify parent directory is renamed if it matches the old project name
- [ ] Verify project is removed from solution during rename and re-added after
- [ ] Verify project still loads correctly in solution after rename

Closes #20, closes #21, closes #22