### PR TITLE
feat(rename): rename parent directory if it matches project name

### DIFF
--- a/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
+++ b/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
@@ -89,9 +89,11 @@ namespace CodingWithCalvin.ProjectRenamifier
             // Rename the project file on disk
             projectFilePath = ProjectFileService.RenameProjectFile(projectFilePath, newName);
 
+            // Rename parent directory if it matches the old project name
+            projectFilePath = ProjectFileService.RenameParentDirectoryIfMatches(projectFilePath, currentName, newName);
+
             // TODO: Implement remaining rename operations
             // See open issues for requirements:
-            // - #21: Rename parent directory if it matches project name
             // - #22: Remove and re-add project to solution
             // - #23: Update project references
             // - #9: Update using statements across solution

--- a/src/CodingWithCalvin.ProjectRenamifier/Services/ProjectFileService.cs
+++ b/src/CodingWithCalvin.ProjectRenamifier/Services/ProjectFileService.cs
@@ -27,6 +27,39 @@ namespace CodingWithCalvin.ProjectRenamifier.Services
         }
 
         /// <summary>
+        /// Renames the parent directory if its name matches the old project name.
+        /// </summary>
+        /// <param name="projectFilePath">Full path to the .csproj file.</param>
+        /// <param name="oldName">The old project name to match against.</param>
+        /// <param name="newName">The new project name.</param>
+        /// <returns>The new full path to the project file after directory rename, or the original path if no rename occurred.</returns>
+        public static string RenameParentDirectoryIfMatches(string projectFilePath, string oldName, string newName)
+        {
+            var projectDirectory = Path.GetDirectoryName(projectFilePath);
+            var parentDirectory = Directory.GetParent(projectDirectory);
+
+            if (parentDirectory == null)
+            {
+                return projectFilePath;
+            }
+
+            var directoryName = new DirectoryInfo(projectDirectory).Name;
+
+            // Only rename if directory name matches the old project name
+            if (!directoryName.Equals(oldName, StringComparison.OrdinalIgnoreCase))
+            {
+                return projectFilePath;
+            }
+
+            var newDirectoryPath = Path.Combine(parentDirectory.FullName, newName);
+            Directory.Move(projectDirectory, newDirectoryPath);
+
+            // Return the new project file path
+            var fileName = Path.GetFileName(projectFilePath);
+            return Path.Combine(newDirectoryPath, fileName);
+        }
+
+        /// <summary>
         /// Updates the RootNamespace and AssemblyName elements in a project file
         /// if they match the old project name.
         /// </summary>


### PR DESCRIPTION
## Summary
- Adds `RenameParentDirectoryIfMatches` method to rename the project's parent directory when it matches the old project name
- Only renames directory if folder name matches old project name (case-insensitive)
- Returns updated project file path after directory rename

## Example
```
Before: C:\Projects\MyProject\MyProject.csproj
After:  C:\Projects\NewName\NewName.csproj
```

## Test plan
- [ ] Test with project where folder matches project name - directory should rename
- [ ] Test with project where folder differs from project name - directory should NOT rename
- [ ] Verify project file path is correctly updated after rename

Closes #21