### PR TITLE
feat(namespace): update using statements across solution

### DIFF
--- a/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
+++ b/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
@@ -105,9 +105,11 @@ namespace CodingWithCalvin.ProjectRenamifier
             // Re-add project to solution with new path
             dte.Solution.AddFromFile(projectFilePath);
 
+            // Update using statements across the entire solution
+            SourceFileService.UpdateUsingStatementsInSolution(dte.Solution, currentName, newName);
+
             // TODO: Implement remaining rename operations
             // See open issues for requirements:
-            // - #9: Update using statements across solution
             // - #11: Solution folder support
             // - #12: Progress indication
             // - #13: Error handling and rollback


### PR DESCRIPTION
## Summary
Updates `using` statements that reference the old namespace throughout the entire solution.

## Changes
- Added `UpdateUsingStatementsInSolution` to scan all projects in the solution
- Added `UpdateUsingStatementsInFile` to handle all using statement variants:
  - `using OldName;` → `using NewName;`
  - `using OldName.SubNamespace;` → `using NewName.SubNamespace;`
  - `using Alias = OldName.Type;` → `using Alias = NewName.Type;`
  - `global using OldName;` → `global using NewName;`
  - `using static OldName.ClassName;` → `using static NewName.ClassName;`
- Recursively handles solution folders

## Test plan
- [ ] Rename a project that other projects have `using` statements for
- [ ] Verify `using OldName;` statements are updated to `using NewName;`
- [ ] Verify nested usings like `using OldName.Sub;` are updated
- [ ] Verify using aliases are updated
- [ ] Verify solution still builds after rename

Closes #9