### PR TITLE
feat(solution): preserve solution folder location during rename

### DIFF
--- a/src/CodingWithCalvin.ProjectRenamifier/CodingWithCalvin.ProjectRenamifier.csproj
+++ b/src/CodingWithCalvin.ProjectRenamifier/CodingWithCalvin.ProjectRenamifier.csproj
@@ -72,6 +72,7 @@
     <Compile Include="ProjectRenamifierPackage.cs" />
     <Compile Include="Services\ProjectFileService.cs" />
     <Compile Include="Services\ProjectReferenceService.cs" />
+    <Compile Include="Services\SolutionFolderService.cs" />
     <Compile Include="Services\SourceFileService.cs" />
     <Compile Include="source.extension.cs">
       <AutoGen>True</AutoGen>

--- a/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
+++ b/src/CodingWithCalvin.ProjectRenamifier/Commands/RenamifyProjectCommand.cs
@@ -84,6 +84,9 @@ namespace CodingWithCalvin.ProjectRenamifier
             var referencingProjects = ProjectReferenceService.FindProjectsReferencingTarget(dte.Solution, projectFilePath);
             var oldProjectFilePath = projectFilePath;
 
+            // Capture the parent solution folder before removal
+            var parentSolutionFolder = SolutionFolderService.GetParentSolutionFolder(project);
+
             // Remove project from solution before file operations
             dte.Solution.Remove(project);
 
@@ -102,15 +105,14 @@ namespace CodingWithCalvin.ProjectRenamifier
             // Update references in projects that referenced this project
             ProjectReferenceService.UpdateProjectReferences(referencingProjects, oldProjectFilePath, projectFilePath);
 
-            // Re-add project to solution with new path
-            dte.Solution.AddFromFile(projectFilePath);
+            // Re-add project to solution, preserving solution folder location
+            SolutionFolderService.AddProjectToSolution(dte.Solution, projectFilePath, parentSolutionFolder);
 
             // Update using statements across the entire solution
             SourceFileService.UpdateUsingStatementsInSolution(dte.Solution, currentName, newName);
 
             // TODO: Implement remaining rename operations
             // See open issues for requirements:
-            // - #11: Solution folder support
             // - #12: Progress indication
             // - #13: Error handling and rollback
         }

--- a/src/CodingWithCalvin.ProjectRenamifier/Services/SolutionFolderService.cs
+++ b/src/CodingWithCalvin.ProjectRenamifier/Services/SolutionFolderService.cs
@@ -1,0 +1,58 @@
+using EnvDTE;
+using EnvDTE80;
+
+namespace CodingWithCalvin.ProjectRenamifier.Services
+{
+    /// <summary>
+    /// Service for managing solution folder operations.
+    /// </summary>
+    internal static class SolutionFolderService
+    {
+        /// <summary>
+        /// Gets the solution folder that contains the specified project, if any.
+        /// </summary>
+        /// <param name="project">The project to find the parent folder for.</param>
+        /// <returns>The parent solution folder project, or null if the project is at the solution root.</returns>
+        public static Project GetParentSolutionFolder(Project project)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (project?.ParentProjectItem?.ContainingProject != null)
+            {
+                var parent = project.ParentProjectItem.ContainingProject;
+
+                // Verify it's actually a solution folder
+                if (parent.Kind == EnvDTE.Constants.vsProjectKindSolutionItems)
+                {
+                    return parent;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Adds a project to the solution, placing it in the specified solution folder if provided.
+        /// </summary>
+        /// <param name="solution">The solution to add the project to.</param>
+        /// <param name="projectFilePath">The full path to the project file.</param>
+        /// <param name="parentSolutionFolder">The solution folder to add the project to, or null for solution root.</param>
+        /// <returns>The added project.</returns>
+        public static Project AddProjectToSolution(Solution solution, string projectFilePath, Project parentSolutionFolder)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            if (parentSolutionFolder != null)
+            {
+                // Add to the solution folder
+                var solutionFolder = (SolutionFolder)parentSolutionFolder.Object;
+                return solutionFolder.AddFromFile(projectFilePath);
+            }
+            else
+            {
+                // Add to solution root
+                return solution.AddFromFile(projectFilePath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Preserves a project's location within solution folders when renaming.

## Changes
- Added `SolutionFolderService` with:
  - `GetParentSolutionFolder` - captures the solution folder containing a project
  - `AddProjectToSolution` - adds project to solution root or specific solution folder
- Updated `RenamifyProjectCommand` to:
  - Capture parent solution folder before removal
  - Re-add project to the same solution folder after rename

## Before this change
Projects in solution folders would be moved to the solution root after rename.

## After this change
Projects stay in their original solution folder location.

## Test plan
- [ ] Rename a project at solution root - should stay at root
- [ ] Rename a project inside a solution folder - should stay in that folder
- [ ] Rename a project in a nested solution folder - should stay in nested folder

Closes #11