### PR TITLE
ci(workflow): remove social media inputs from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,5 +14,4 @@ jobs:
       extension-name: ProjectRenamifier
       display-name: 'Project Renamifier'
       marketplace-id: CodingWithCalvin.VS-ProjectRenamifier
-      description: 'Safely rename projects in Visual Studio with namespace and reference updates'
     secrets: inherit


### PR DESCRIPTION
## Summary
- Remove social media inputs (`description`, `hashtags`) from publish workflow that are no longer used by the reusable vsix-publish workflow

## Test plan
- [ ] Verify publish workflow still works correctly