### PR TITLE
docs(readme): remove retired VS Marketplace shields.io badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,6 @@
   </a>
 </p>
 
-<p align="center">
-  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-ProjectRenamifier">
-    <img src="https://img.shields.io/visual-studio-marketplace/v/CodingWithCalvin.VS-ProjectRenamifier?style=for-the-badge" alt="Marketplace Version">
-  </a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-ProjectRenamifier">
-    <img src="https://img.shields.io/visual-studio-marketplace/i/CodingWithCalvin.VS-ProjectRenamifier?style=for-the-badge" alt="Marketplace Installations">
-  </a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-ProjectRenamifier">
-    <img src="https://img.shields.io/visual-studio-marketplace/d/CodingWithCalvin.VS-ProjectRenamifier?style=for-the-badge" alt="Marketplace Downloads">
-  </a>
-  <a href="https://marketplace.visualstudio.com/items?itemName=CodingWithCalvin.VS-ProjectRenamifier">
-    <img src="https://img.shields.io/visual-studio-marketplace/r/CodingWithCalvin.VS-ProjectRenamifier?style=for-the-badge" alt="Marketplace Rating">
-  </a>
-</p>
-
 ---
 
 Tired of the tedious, error-prone process of renaming a project in Visual Studio? Say goodbye to manual find-and-replace across dozens of files! **Project Renamifier** handles everything automatically - one click, one dialog, done!


### PR DESCRIPTION
## Summary
- Removed retired shields.io Visual Studio Marketplace badges (Version, Installs, Downloads, Rating)
- The `visual-studio-marketplace` endpoint on shields.io has been retired and all badges show "Retired Badge"
- License and Build Status badges are unaffected and remain